### PR TITLE
commits to master

### DIFF
--- a/nanslice/__init__.py
+++ b/nanslice/__init__.py
@@ -6,5 +6,5 @@ and the :py:func:`~nanslice.layer.blend_layers` function, are imported here
 for convenient access. Between them, they do all the important work.
 """
 
-from .layer import Layer, blend_layers
+from .layer import Layer, blend_layers, ROILayer, roi_image_from_csv
 from .slicer import Slicer

--- a/nanslice/box.py
+++ b/nanslice/box.py
@@ -36,18 +36,18 @@ class Box:
         return 'Box Start: ' + str(self.start) + ' End: ' + str(self.end)
 
     @classmethod
-    def fromImage(cls, shape, affine):
+    def fromImage(cls, img):
         """
         Creates a bounding box from the corners defined by an image
 
         Parameters:
 
-        - shape  -- The shape of the image data array
-        - affine -- The affine transform for the image
+        - img -- An nibabel image
         """
+        img_shape = img.get_fdata().shape
         corners = np.array([[0, 0, 0, 1.],
-                            [shape[0] - 1, shape[1] - 1, shape[2] - 1, 1.]])
-        corners = np.dot(affine, corners.T)
+                            [img_shape[0] - 1, img_shape[1] - 1, img_shape[2] - 1, 1.]])
+        corners = np.dot(img.get_sform(), corners.T)
         corner1 = np.min(corners[0:3, :], axis=1)
         corner2 = np.max(corners[0:3, :], axis=1)
         return cls(corners=(corner1, corner2))

--- a/nanslice/box.py
+++ b/nanslice/box.py
@@ -62,7 +62,7 @@ class Box:
         - img -- The volume to create the bounding-box from
         - padding -- Number of extra voxels to pad the resulting box by
         """
-        data = img.get_data()
+        data = img.get_fdata()
 
         # Individual axis min/maxes
         xmin, xmax = np.where(np.any(data, axis=(1, 2)))[0][[0, -1]]
@@ -72,7 +72,7 @@ class Box:
         # Convedir_rt to physical space
         corners = np.array([[xmin, ymin, zmin, 1.],
                             [xmax, ymax, zmax, 1.]])
-        corners = np.dot(img.affine, corners.T)
+        corners = np.dot(img.get_sform(), corners.T)
         # Now do min/maxes again to standardise corners
         corner1 = np.min(corners[0:3, :], axis=1) - padding
         corner2 = np.max(corners[0:3, :], axis=1) + padding

--- a/nanslice/layer.py
+++ b/nanslice/layer.py
@@ -6,6 +6,9 @@ function.
 """
 import scipy.ndimage.interpolation as ndinterp
 import h5py
+import numpy as np
+import pandas as pd
+import nibabel as nib
 from numpy import zeros, isfinite, nanpercentile, ma, ones_like, array, iscomplexobj, abs, angle, mat, dot, eye
 from nibabel import load
 from . import slice_func
@@ -233,6 +236,139 @@ def blend_layers(layers, slicer):
         else:
             slc = slice_func.mask(next_slc, next_layer.get_mask(slicer), slc)
     return slc
+
+
+def roi_image_from_csv(label_image, csv_file, label_col=None, value_col=None):
+    """
+    Creates an in-memory nibabel image where each ROI voxel is assigned the
+    corresponding value from a CSV file (a "stained glass" value map).
+
+    Parameters:
+
+    - label_image -- Path or nibabel image of an integer-valued atlas/ROI file
+    - csv_file    -- Path to a CSV file (or a pandas DataFrame) mapping label IDs to values.
+                     The file must have one column with integer label IDs and one with the values.
+    - label_col   -- Name or index of the column containing ROI integer labels.
+                     Defaults to the first column.
+    - value_col   -- Name or index of the column containing the values to map.
+                     Defaults to the second column.
+
+    Returns a nibabel Nifti1Image with the same affine/header as *label_image*
+    and float32 data where every voxel belonging to a labelled ROI holds the
+    corresponding value (0 for labels absent from the CSV, NaN for background
+    label 0).
+    """
+    img = ensure_image(label_image)
+    label_data = np.round(img.get_fdata()).astype(np.int32)
+
+    if isinstance(csv_file, pd.DataFrame):
+        df = csv_file
+    else:
+        df = pd.read_csv(csv_file)
+
+    if label_col is None:
+        label_col = df.columns[0]
+    if value_col is None:
+        value_col = df.columns[1]
+
+    value_map = dict(zip(df[label_col].astype(int), df[value_col].astype(float)))
+
+    value_data = np.full(label_data.shape, np.nan, dtype=np.float32)
+    for label_id, val in value_map.items():
+        value_data[label_data == label_id] = val
+
+    return nib.Nifti1Image(value_data, img.affine, img.header)
+
+
+class ROILayer(Layer):
+    """
+    A Layer built from an integer atlas/ROI NIfTI and a CSV of per-ROI values,
+    producing a "stained glass" overlay where each region is filled with a
+    uniform colour derived from the mapped value.
+
+    Constructor parameters (in addition to standard :py:class:`Layer` parameters):
+
+    - label_image    -- Path or nibabel image with integer ROI labels
+    - csv_file       -- Path to CSV file (or a pandas DataFrame) with label → value mapping
+    - label_col      -- Column name/index for the integer label IDs (default: first column)
+    - value_col      -- Column name/index for the values to map (default: second column)
+    - cmap           -- Colormap to apply (default: 'RdYlBu_r')
+    - clim           -- (min, max) limits for colormap; computed from data if not given
+    - mask_threshold -- Threshold to mask background; default 0 (masks NaN/zero background)
+    - contour        -- Draw boundary contours around each ROI (default: True)
+    - contour_color  -- Matplotlib color for the contour lines (default: 'k')
+    - contour_linewidth -- Line width of the contour lines (default: 0.5)
+
+    All other :py:class:`Layer` keyword arguments are forwarded as-is.
+
+    Example::
+
+        bg  = Layer('T1.nii.gz', cmap='gist_gray')
+        roi = ROILayer('atlas.nii.gz', 'stats.csv',
+                       label_col='roi_id', value_col='t_stat',
+                       cmap='RdYlBu_r', clim=(-4, 4),
+                       contour=True, contour_color='white', contour_linewidth=0.8)
+        fig, axes = plt.subplots(1, 3)
+        slicers = [Slicer(bg.bbox, pos, 'z') for pos in [0.4, 0.5, 0.6]]
+        for ax, sl in zip(axes, slicers):
+            ax.imshow(blend_layers([bg, roi], sl), origin='lower', extent=sl.extent)
+            roi.plot_contours(sl, ax)
+    """
+
+    def __init__(self, label_image, csv_file,
+                 label_col=None, value_col=None,
+                 cmap='RdYlBu_r', clim=None, mask_threshold=0,
+                 contour=True, contour_color='k', contour_linewidth=0.5,
+                 **kwargs):
+        label_img = ensure_image(label_image)
+        self._label_data = np.round(label_img.get_fdata()).astype(np.int32)
+        self._label_affine = label_img.affine
+        self.contour = contour
+        self.contour_color = contour_color
+        self.contour_linewidth = contour_linewidth
+
+        value_img = roi_image_from_csv(label_img, csv_file, label_col, value_col)
+        # Use nearest-neighbour interpolation to keep hard ROI boundaries
+        super().__init__(value_img, cmap=cmap, clim=clim,
+                         interp_order=0, mask_threshold=mask_threshold,
+                         **kwargs)
+
+    def plot_contours(self, slicer, axes):
+        """
+        Draw boundary contours around each ROI onto a matplotlib axes.
+
+        Call this after ``blend_layers`` to add contours when the fill is
+        rendered via the blend pipeline rather than through ``plot()``.
+
+        Parameters:
+
+        - slicer -- The :py:class:`~nanslice.slicer.Slicer` used for the slice
+        - axes   -- A matplotlib axes object
+        """
+        label_slice = slicer.sample(self._label_data, self._label_affine, 0)
+        unique_labels = np.unique(label_slice)
+        # Build contour levels at half-integer boundaries between distinct labels
+        levels = unique_labels[unique_labels > 0] - 0.5
+        if len(levels) == 0:
+            return
+        axes.contour(label_slice, levels=levels,
+                     colors=self.contour_color,
+                     linewidths=self.contour_linewidth,
+                     extent=slicer.extent, origin='lower')
+
+    def plot(self, slicer, axes):
+        """
+        Plot the ROI fill and, if *contour* is True, the boundary contours.
+
+        Parameters:
+
+        - slicer -- The :py:class:`~nanslice.slicer.Slicer` object to slice with
+        - axes   -- A matplotlib axes object
+        """
+        cax = super().plot(slicer, axes)
+        if self.contour:
+            self.plot_contours(slicer, axes)
+        return cax
 
 
 class H5Layer(Layer):

--- a/nanslice/layer.py
+++ b/nanslice/layer.py
@@ -85,7 +85,7 @@ class Layer:
         elif self.mask_image:
             self.bbox = Box.fromMask(self.mask_image)
         else:
-            self.bbox = Box.fromImage(self.shape, self.affine)
+            self.bbox = Box.fromImage(self.image)
 
         if clim is not None:
             self.clim = clim

--- a/nanslice/layer.py
+++ b/nanslice/layer.py
@@ -9,7 +9,7 @@ import h5py
 import numpy as np
 import pandas as pd
 import nibabel as nib
-from numpy import zeros, isfinite, nanpercentile, ma, ones_like, array, iscomplexobj, abs, angle, mat, dot, eye
+from numpy import zeros, isfinite, nanpercentile, ma, ones_like, array, iscomplexobj, abs, angle
 from nibabel import load
 from . import slice_func
 from .box import Box
@@ -88,7 +88,7 @@ class Layer:
         elif self.mask_image:
             self.bbox = Box.fromMask(self.mask_image)
         else:
-            self.bbox = Box.fromImage(self.image)
+            self.bbox = Box.fromImage(image)
 
         if clim is not None:
             self.clim = clim
@@ -139,10 +139,10 @@ class Layer:
 
         - pos -- The position to sample the image value at
         """
-        pos = mat(pos).T
-        scale = mat(self.affine[0:3, 0:3]).I
-        offset = dot(-scale, self.affine[0:3, 3]).T
-        vox = dot(scale, pos) + offset
+        pos = np.array(pos).reshape(3, 1)
+        scale = np.linalg.inv(self.affine[0:3, 0:3])
+        offset = (-scale @ self.affine[0:3, 3]).reshape(3, 1)
+        vox = scale @ pos + offset
         if len(self.shape) == 4:
             new_vox = zeros((4, 1))
             new_vox[0:3, :] = vox
@@ -272,10 +272,12 @@ def roi_image_from_csv(label_image, csv_file, label_col=None, value_col=None):
         value_col = df.columns[1]
 
     value_map = dict(zip(df[label_col].astype(int), df[value_col].astype(float)))
+    value_map.pop(0, None)  # always ignore background label 0
 
     value_data = np.full(label_data.shape, np.nan, dtype=np.float32)
     for label_id, val in value_map.items():
         value_data[label_data == label_id] = val
+    # Voxels with label > 0 but absent from the CSV stay NaN → masked out
 
     return nib.Nifti1Image(value_data, img.affine, img.header)
 
@@ -332,6 +334,11 @@ class ROILayer(Layer):
         super().__init__(value_img, cmap=cmap, clim=clim,
                          interp_order=0, mask_threshold=mask_threshold,
                          **kwargs)
+
+    def get_mask(self, slicer):
+        """Show only voxels where a label > 0 exists in the atlas."""
+        label_slice = slicer.sample(self._label_data, self._label_affine, 0)
+        return label_slice > 0
 
     def plot_contours(self, slicer, axes):
         """

--- a/nanslice/nanslicer.py
+++ b/nanslice/nanslicer.py
@@ -166,6 +166,8 @@ def main(args=None):
         sl_final = blend_layers(layers, slcr)
         ax.imshow(sl_final, origin=origin, extent=slcr.extent,
                   interpolation=args.interp)
+        if args.radiological:
+            ax.invert_xaxis()
         ax.axis('off')
         if args.contour:
             sl_contour = layers[1].get_alpha(slcr)

--- a/nanslice/roislicer.py
+++ b/nanslice/roislicer.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python
+"""roislicer.py
+
+Command-line tool for producing "stained glass" ROI overlay figures.
+Requires an integer-labelled atlas NIfTI and a CSV file that maps each
+label to a scalar value (t-statistic, p-value, group mean, etc.).
+
+Minimum call::
+
+    roislicer T1.nii.gz atlas.nii.gz stats.csv output.png
+
+The CSV must have at least two columns: one with integer ROI label IDs and
+one with the corresponding scalar values.  By default the first column is
+taken as the label column and the second as the value column.  Use
+``--label_col`` and ``--value_col`` to specify column names explicitly.
+
+All common slicing options from ``nanslicer`` are supported.
+"""
+import argparse
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+
+from .util import add_common_arguments, Axis_map
+from .colorbar import colorbar
+from .box import Box
+from .slicer import Slicer
+from .layer import Layer, ROILayer, blend_layers
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser(
+        description='Stained-glass ROI overlay: colour atlas regions by a CSV value')
+    # Positional arguments
+    parser.add_argument('base_image', help='Background structural image', type=str)
+    parser.add_argument('label_image', help='Integer-labelled atlas/ROI NIfTI', type=str)
+    parser.add_argument('csv_file', help='CSV file with label → value mapping', type=str)
+    parser.add_argument('output', help='Output image filename', type=str)
+
+    # CSV column selection
+    parser.add_argument('--label_col', type=str, default=None,
+                        help='Column name for ROI integer labels (default: first column)')
+    parser.add_argument('--value_col', type=str, default=None,
+                        help='Column name for scalar values (default: second column)')
+
+    # Base image display
+    parser.add_argument('--base_map', type=str, default='gist_gray',
+                        help='Colormap for the background image (default: gist_gray)')
+    parser.add_argument('--base_lims', type=float, nargs=2, default=None,
+                        help='Window limits for the background image')
+    parser.add_argument('--mask', type=str, default=None,
+                        help='Mask image for the background layer')
+
+    # ROI overlay display
+    parser.add_argument('--roi_map', type=str, default='RdYlBu_r',
+                        help='Colormap for the ROI overlay (default: RdYlBu_r)')
+    parser.add_argument('--roi_lim', type=float, nargs=2, default=None,
+                        help='Color limits for ROI values (auto-computed if omitted)')
+    parser.add_argument('--roi_label', type=str, default='',
+                        help='Label for the ROI colorbar')
+    parser.add_argument('--roi_alpha', type=float, default=1.0,
+                        help='Overall opacity of the ROI overlay (0–1, default: 1.0)')
+
+    # Contour options
+    parser.add_argument('--no_contour', action='store_true',
+                        help='Disable ROI boundary contours')
+    parser.add_argument('--contour_color', type=str, default='k',
+                        help='Color for ROI boundary contours (default: k = black)')
+    parser.add_argument('--contour_linewidth', type=float, default=0.5,
+                        help='Line width of ROI boundary contours (default: 0.5)')
+
+    # Slicing options
+    parser.add_argument('--slice_rows', type=int, default=4,
+                        help='Number of rows of slices (default: 4)')
+    parser.add_argument('--slice_cols', type=int, default=5,
+                        help='Number of columns of slices (default: 5)')
+    parser.add_argument('--slice_axis', type=str, default='z',
+                        help='Axis to slice along: x/y/z (default: z)')
+    parser.add_argument('--slice_lims', type=float, nargs=2, default=(0.1, 0.9),
+                        help='Start and end fractions along the slice axis (default: 0.1 0.9)')
+    parser.add_argument('--slices', type=float, nargs='+',
+                        help='Slice at explicit positions (overrides --slice_rows/cols/lims)')
+    parser.add_argument('--three_axis', action='store_true',
+                        help='Show one slice per axis (x, y, z) through the image centre')
+    parser.add_argument('--samples', type=int, default=128,
+                        help='Sampling resolution per slice (default: 128)')
+    parser.add_argument('--interp', type=str, default='hanning',
+                        help='Matplotlib interpolation for display (default: hanning)')
+    parser.add_argument('--orient', type=str, default='clin',
+                        help='Slice orientation: clin or preclin (default: clin)')
+    parser.add_argument('--radiological', action='store_true',
+                        help='Flip left/right (radiological convention)')
+
+    # Figure options
+    parser.add_argument('--bar_pos', type=str, default='south',
+                        help='Colorbar position: north/south/east/west (default: south)')
+    parser.add_argument('--no_colorbar', action='store_true',
+                        help='Do not add a colorbar')
+    parser.add_argument('--figsize', type=float, nargs=2, default=None,
+                        help='Figure size in inches: width height')
+    parser.add_argument('--dpi', type=int, default=150,
+                        help='Output DPI (default: 150)')
+    parser.add_argument('--font', type=str, default='Helvetica',
+                        help='Font family (default: Helvetica)')
+    parser.add_argument('--fontsize', type=int, default=8,
+                        help='Font size in pt (default: 8)')
+    parser.add_argument('--title', type=str, default=None,
+                        help='Optional title text on the figure')
+    parser.add_argument('--crop_center', type=float, nargs=3,
+                        help='Centre of crop box (X Y Z) in mm')
+    parser.add_argument('--crop_size', type=float, nargs=3,
+                        help='Size of crop box (X Y Z) in mm')
+
+    args = parser.parse_args()
+
+    mpl.rc('font', family=args.font, size=args.fontsize)
+
+    # --- Build layers -------------------------------------------------------
+    print('*** Loading background image:', args.base_image)
+    bg = Layer(args.base_image,
+               mask=args.mask,
+               crop_center=args.crop_center,
+               crop_size=args.crop_size,
+               cmap=args.base_map,
+               clim=args.base_lims)
+    if args.base_lims is None:
+        print('    Background limits:', bg.clim)
+
+    print('*** Loading ROI layer:', args.label_image, '+', args.csv_file)
+    roi = ROILayer(args.label_image, args.csv_file,
+                   label_col=args.label_col,
+                   value_col=args.value_col,
+                   cmap=args.roi_map,
+                   clim=args.roi_lim,
+                   label=args.roi_label,
+                   contour=not args.no_contour,
+                   contour_color=args.contour_color,
+                   contour_linewidth=args.contour_linewidth)
+    print('    ROI value limits:', roi.clim)
+
+    # --- Compute slice positions --------------------------------------------
+    bbox = bg.bbox
+    slice_axis_idx = Axis_map[args.slice_axis]
+
+    if args.three_axis:
+        slice_rows, slice_cols = 1, 3
+        slice_axes = [0, 1, 2]
+        slice_pos = [bbox.center[0], bbox.center[1], bbox.center[2]]
+        slice_total = 3
+    elif args.slices:
+        slice_total = len(args.slices)
+        slice_rows = args.slice_rows
+        slice_cols = args.slice_cols
+        slice_pos = np.array(args.slices)
+        slice_axes = [slice_axis_idx] * slice_total
+    else:
+        slice_rows = args.slice_rows
+        slice_cols = args.slice_cols
+        slice_total = slice_rows * slice_cols
+        slice_pos = (bbox.start[slice_axis_idx] +
+                     bbox.diag[slice_axis_idx] *
+                     np.linspace(args.slice_lims[0], args.slice_lims[1], slice_total))
+        slice_axes = [slice_axis_idx] * slice_total
+
+    print(f'*** Slicing: {slice_total} slices in {slice_rows} rows × {slice_cols} columns')
+
+    origin = 'upper' if args.orient == 'preclin' else 'lower'
+
+    # --- Layout -------------------------------------------------------------
+    if not args.figsize:
+        args.figsize = (3 * slice_cols, 3 * slice_rows)
+    figure = plt.figure(facecolor='black', figsize=args.figsize)
+    gs1 = gridspec.GridSpec(slice_rows, slice_cols)
+
+    # --- Draw slices --------------------------------------------------------
+    for s in range(slice_total):
+        row, col = divmod(s, slice_cols)
+        ax = plt.subplot(gs1[row, col], facecolor='black')
+        slcr = Slicer(bbox, slice_pos[s], slice_axes[s],
+                      args.samples, orient=args.orient)
+        composite = blend_layers([bg, roi], slcr)
+        ax.imshow(composite, origin=origin, extent=slcr.extent,
+                  interpolation=args.interp)
+        if args.radiological:
+            ax.invert_xaxis()
+        roi.plot_contours(slcr, ax)
+        ax.axis('off')
+
+    # --- Colorbar -----------------------------------------------------------
+    if args.roi_label and not args.no_colorbar:
+        print('*** Adding colorbar')
+        if args.bar_pos.lower() == 'south':
+            cbar_bottom = 0.3 * (args.fontsize / 12) / args.figsize[1]
+            cbar_top = cbar_bottom + 0.1 / args.figsize[1]
+            gs1.update(left=0.01, right=0.99, bottom=cbar_top + 0.001,
+                       top=0.99, wspace=0.01, hspace=0.01)
+            gs2 = gridspec.GridSpec(1, 1)
+            gs2.update(left=0.1, right=0.9, bottom=cbar_bottom,
+                       top=cbar_top, wspace=0.1, hspace=0.1)
+            c_orient = 'h'
+        elif args.bar_pos.lower() == 'north':
+            cbarh = 0.15 * (args.fontsize / 12) / args.figsize[1]
+            gs1.update(left=0.01, right=0.99, bottom=0.01,
+                       top=0.99 - cbarh, wspace=0.01, hspace=0.01)
+            gs2 = gridspec.GridSpec(1, 1)
+            gs2.update(left=0.07, right=0.93, bottom=0.99 - cbarh,
+                       top=0.99, wspace=0.01, hspace=0.01)
+            c_orient = 'h'
+        elif args.bar_pos.lower() == 'west':
+            cbarw = 0.275 * (args.fontsize / 12) / args.figsize[0]
+            gs1.update(left=0.01 + cbarw, right=0.99, bottom=0.01,
+                       top=0.99, wspace=0.01, hspace=0.01)
+            gs2 = gridspec.GridSpec(1, 1)
+            gs2.update(left=0.01, right=cbarw, bottom=0.08,
+                       top=0.92, wspace=0.01, hspace=0.01)
+            c_orient = 'v'
+        elif args.bar_pos.lower() == 'east':
+            cbarw = 0.35 * (args.fontsize / 12) / args.figsize[0]
+            gs1.update(left=0.01, right=1 - cbarw, bottom=0.01,
+                       top=0.99, wspace=0.01, hspace=0.01)
+            gs2 = gridspec.GridSpec(1, 1)
+            gs2.update(left=1 - cbarw + 0.001, right=1 - cbarw / 1.5,
+                       bottom=0.08, top=0.92, wspace=0.01, hspace=0.01)
+            c_orient = 'v'
+        else:
+            raise ValueError('Unsupported bar position: ' + args.bar_pos)
+
+        c_axes = plt.subplot(gs2[0], facecolor='black')
+        colorbar(c_axes, roi.cmap, roi.clim, args.roi_label, orient=c_orient)
+    else:
+        gs1.update(left=0.01, right=0.99, bottom=0.01,
+                   top=0.99, wspace=0.01, hspace=0.01)
+
+    if args.title:
+        figure.axes[-1].text(0.01, 0.99, args.title, color='w',
+                             size=args.fontsize, verticalalignment='top',
+                             transform=figure.transFigure)
+
+    print('*** Saving:', args.output, 'at', args.dpi, 'DPI')
+    figure.savefig(args.output, facecolor=figure.get_facecolor(),
+                   edgecolor='none', dpi=args.dpi)
+    plt.close(figure)
+
+
+if __name__ == '__main__':
+    main()

--- a/nanslice/slicer.py
+++ b/nanslice/slicer.py
@@ -62,7 +62,7 @@ class Slicer:
         if not np.array_equal(tfm, self._tfm):
             old_sz = self._world_space.shape
             new_sz = np.prod(self._world_space.shape[1:])
-            scale = np.mat(tfm[0:3, 0:3]).I
+            scale = np.asmatrix(tfm[0:3, 0:3]).I
             offset = np.dot(-scale, tfm[0:3, 3]).T
             isl = np.dot(scale, self._world_space.reshape(
                 [3, new_sz])) + offset[:]

--- a/nanslice/util.py
+++ b/nanslice/util.py
@@ -90,6 +90,9 @@ def add_common_arguments(parser):
                         help='Data interpolation order, default=1')
     parser.add_argument('--orient', type=str, default='clin',
                         help='Clinical (clin) or Pre-clinical (preclin) orientation')
+    parser.add_argument('--radiological', action='store_true',
+                        help='Display images in radiological convention (patient left on viewer right). '
+                             'Default is neurological convention (patient left on viewer left).')
     return parser
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
         'console_scripts': [
             'nanslicer=nanslice.nanslicer:main',
             'nanviewer=nanslice.nanviewer:main',
-            'nanscroll=nanslice.nanscroll:main'
+            'nanscroll=nanslice.nanscroll:main',
+            'roislicer=nanslice.roislicer:main'
         ],
     },
 )


### PR DESCRIPTION
```
import matplotlib.pyplot as plt
from nanslice import Layer, ROILayer, blend_layers, Slicer

bg = Layer('T1.nii.gz', cmap='gist_gray')

roi = ROILayer(
    'atlas.nii.gz',
    'stats.csv',
    label_col='roi_id',
    value_col='t_stat',
    cmap='RdYlBu_r',
    clim=(-5, 5),
    label='t-stat',
)

slices = [0.35, 0.45, 0.55, 0.65]
fig, axes = plt.subplots(1, len(slices), figsize=(12, 3))
for ax, pos in zip(axes, slices):
    sl = Slicer(bg.bbox, pos, 'z', samples=128)
    ax.imshow(blend_layers([bg, roi], sl), origin='lower', extent=sl.extent)
    ax.axis('off')
plt.tight_layout()
plt.savefig('stained_glass.png', dpi=150)

```


or from cli:

```
example usage:
roislicer T1.nii.gz aal.nii.gz group_comparison.csv stained.png \
    --label_col roi_id --value_col t_stat \
    --roi_map RdYlBu_r --roi_lim -4 4 --roi_label "t-stat" \
    --contour_color white --contour_linewidth 0.8 \
    --slice_axis z --slice_rows 3 --slice_cols 6 \
    --bar_pos south --dpi 200 --title "Group A > Group B"

```
This pull request introduces significant new functionality for ROI-based visualization, improves the handling of image and mask data, and adds a new command-line tool for "stained glass" ROI overlays. The most important changes are grouped below.

### New ROI Overlay Functionality

* Added `ROILayer` class and `roi_image_from_csv` function to `layer.py`, enabling creation of overlay layers where each ROI is colored according to values from a CSV file. This supports visualization of region-wise statistics and includes features like contour plotting and flexible colormap/value mapping.
* Exposed `ROILayer` and `roi_image_from_csv` in the package’s top-level `__init__.py` for easy import.

### New Command-Line Tool

* Added `roislicer.py`, a new CLI tool for generating "stained glass" ROI overlay figures from an atlas NIfTI and a CSV mapping file. It supports extensive customization for slicing, coloring, and layout, and is integrated with the new ROI overlay features.

### Improvements to Image Handling and Consistency

* Refactored `Box.fromImage` and `Box.fromMask` to accept nibabel image objects directly and use `get_fdata()` and `get_sform()` for improved compatibility and correctness. [[1]](diffhunk://#diff-c11c41bb635be2b3d07edd477ccb4f81ac7512c497eb418ce8245c9c9706318fL39-R50) [[2]](diffhunk://#diff-c11c41bb635be2b3d07edd477ccb4f81ac7512c497eb418ce8245c9c9706318fL65-R65) [[3]](diffhunk://#diff-c11c41bb635be2b3d07edd477ccb4f81ac7512c497eb418ce8245c9c9706318fL75-R75)
* Updated `Layer.__init__` to use the new `Box.fromImage(image)` signature, ensuring consistent bounding box calculation.
* Modernized the `get_value` method in `Layer` to use `numpy` matrix operations instead of deprecated `numpy.mat`/`dot`, improving maintainability and clarity.

### Display and CLI Enhancements

* Added `--radiological` option to both `nanslicer` and the new `roislicer` tool, allowing users to flip images to radiological convention (patient left on viewer right). [[1]](diffhunk://#diff-24426a7341f9418e71cd9cbc283f6b7fbcd1c0ed2a3f71107fec2d276d923e31R93-R95) [[2]](diffhunk://#diff-702b0e47f38182144d2eca0282491f3381e870844b3d6258c66b8aacd6e16348R169-R170)

### Minor Fixes

* Minor update in `slicer.py` to use `np.asmatrix` instead of `np.mat` for matrix inversion, aligning with current numpy best practices.